### PR TITLE
Update country.py

### DIFF
--- a/foss42/data/geo/country.py
+++ b/foss42/data/geo/country.py
@@ -1103,7 +1103,7 @@ SUB_IN = [{KEY_CODE: 'AN', KEY_NAME: 'Andaman and Nicobar Islands', KEY_CAT: 'un
  {KEY_CODE: 'ML', KEY_NAME: 'Meghalaya', KEY_CAT: 'state'},
  {KEY_CODE: 'MZ', KEY_NAME: 'Mizoram', KEY_CAT: 'state'},
  {KEY_CODE: 'NL', KEY_NAME: 'Nagaland', KEY_CAT: 'state'},
- {KEY_CODE: 'OR', KEY_NAME: 'Odisha', KEY_CAT: 'state'},
+ {KEY_CODE: 'OD', KEY_NAME: 'Odisha', KEY_CAT: 'state'},
  {KEY_CODE: 'PB', KEY_NAME: 'Punjab', KEY_CAT: 'state'},
  {KEY_CODE: 'RJ', KEY_NAME: 'Rajasthan', KEY_CAT: 'state'},
  {KEY_CODE: 'SK', KEY_NAME: 'Sikkim', KEY_CAT: 'state'},

--- a/foss42/data/geo/country.py
+++ b/foss42/data/geo/country.py
@@ -1089,7 +1089,7 @@ SUB_IN = [{KEY_CODE: 'AN', KEY_NAME: 'Andaman and Nicobar Islands', KEY_CAT: 'un
  {KEY_CODE: 'AR', KEY_NAME: 'Arunachal Pradesh', KEY_CAT: 'state'},
  {KEY_CODE: 'AS', KEY_NAME: 'Assam', KEY_CAT: 'state'},
  {KEY_CODE: 'BR', KEY_NAME: 'Bihar', KEY_CAT: 'state'},
- {KEY_CODE: 'CT', KEY_NAME: 'Chhattisgarh', KEY_CAT: 'state'},
+ {KEY_CODE: 'CG', KEY_NAME: 'Chhattisgarh', KEY_CAT: 'state'},
  {KEY_CODE: 'GA', KEY_NAME: 'Goa', KEY_CAT: 'state'},
  {KEY_CODE: 'GJ', KEY_NAME: 'Gujarat', KEY_CAT: 'state'},
  {KEY_CODE: 'HR', KEY_NAME: 'Haryana', KEY_CAT: 'state'},
@@ -1108,10 +1108,10 @@ SUB_IN = [{KEY_CODE: 'AN', KEY_NAME: 'Andaman and Nicobar Islands', KEY_CAT: 'un
  {KEY_CODE: 'RJ', KEY_NAME: 'Rajasthan', KEY_CAT: 'state'},
  {KEY_CODE: 'SK', KEY_NAME: 'Sikkim', KEY_CAT: 'state'},
  {KEY_CODE: 'TN', KEY_NAME: 'Tamil Nadu', KEY_CAT: 'state'},
- {KEY_CODE: 'TG', KEY_NAME: 'Telangana', KEY_CAT: 'state'},
+ {KEY_CODE: 'TS', KEY_NAME: 'Telangana', KEY_CAT: 'state'},
  {KEY_CODE: 'TR', KEY_NAME: 'Tripura', KEY_CAT: 'state'},
  {KEY_CODE: 'UP', KEY_NAME: 'Uttar Pradesh', KEY_CAT: 'state'},
- {KEY_CODE: 'UT', KEY_NAME: 'Uttarakhand', KEY_CAT: 'state'},
+ {KEY_CODE: 'UK', KEY_NAME: 'Uttarakhand', KEY_CAT: 'state'},
  {KEY_CODE: 'WB', KEY_NAME: 'West Bengal', KEY_CAT: 'state'}]
 
 SUB_JP = [{KEY_CODE: '23', KEY_NAME: 'Aichi', KEY_CAT: 'prefecture'},


### PR DESCRIPTION
Corrected the state key for odisha,india,asia

Source1: [LINK: Indian Express](https://www.newindianexpress.com/states/odisha/2012/Sep/01/vehicle-registration-number-od-to-replace-or-from-today-402096.html)

Source2 : [LINK: Wikipedia](https://en.wikipedia.org/wiki/Odisha)
In 2011, the English rendering of ଓଡ଼ିଶା was changed from "Orissa" to "Odisha", and the name of its language from "Oriya" to "Odia", by the passage of the Orissa (Alteration of Name) Bill, 2010 and the Constitution (113th Amendment) Bill, 2010 in the [Parliament](https://en.wikipedia.org/wiki/Indian_Parliament). The Hindi rendering उड़ीसा (uṛīsā) was also modified to ओड़िशा (or̥iśā). After a brief debate, the lower house, [Lok Sabha](https://en.wikipedia.org/wiki/Lok_Sabha), passed the bill and amendment on 9 November 2010.[[30]](https://en.wikipedia.org/wiki/Odisha#cite_note-AmidClashBillPass-30) On 24 March 2011, [Rajya Sabha](https://en.wikipedia.org/wiki/Rajya_Sabha), the upper house of [Parliament](https://en.wikipedia.org/wiki/Parliament), also passed the bill and the amendment.[[31]](https://en.wikipedia.org/wiki/Odisha#cite_note-ChangeOrissaName-31)